### PR TITLE
add demo notebook for loading the flick8k dataset

### DIFF
--- a/DemoNotebooks/test_load_data_&_preproces.ipynb
+++ b/DemoNotebooks/test_load_data_&_preproces.ipynb
@@ -1,0 +1,73 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from Data.datasetloader import Flickr8kDataset\n",
+    "from Data.vocab import Vocabulary\n",
+    "from Data.padding import CollatePadding\n",
+    "from torch.utils.data import DataLoader"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# download the flickr8k dataset\n",
+    "! wget http://cs.stanford.edu/people/karpathy/deepimagesent/flickr8k.zip\n",
+    "! unzip flickr8k.zip"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# create the Flick8k dataset\n",
+    "root_dir = 'flickr8k_dir/Images/'\n",
+    "caption_file = 'flickr8k_dir/captions.txt'\n",
+    "flick8k = Flickr8kDataset(root_dir, caption_file) "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# visualize the first set of image and captions\n",
+    "import matplotlib.pyplot as plt\n",
+    "import matplotlib.image as mpimg\n",
+    "\n",
+    "img, cap = flick8k[0]\n",
+    "print(cap)\n",
+    "plt.imshow(mpimg.imread(img))\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# define the datalodaer for the flickr8k dataset\n",
+    "flick8kdataloader =  DataLoader(flick8k, batch_size=4, shuffle=True, num_workers=4, collate_fn=CollatePadding(pad_idx=pad_idx,batch_first=True))"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
>** The code will only merged after Natalie's Dataloader branch is merged** 

from Data.datasetloader import Flickr8kDataset
from Data.vocab import Vocabulary
from Data.padding import CollatePadding
from torch.utils.data import DataLoader

! wget http://cs.stanford.edu/people/karpathy/deepimagesent/flickr8k.zip
! unzip flickr8k.zip

### create the Flick8k dataset
root_dir = 'flickr8k_dir/Images/'
caption_file = 'flickr8k_dir/captions.txt'
flick8k = Flickr8kDataset(root_dir, caption_file) 

### visualize the first set of image and captions
import matplotlib.pyplot as plt
import matplotlib.image as mpimg

img, cap = flick8k[0]
print(cap)
plt.imshow(mpimg.imread(img))
plt.show()

### define the datalodaer for the flickr8k dataset
flick8kdataloader =  DataLoader(flick8k, batch_size=4, shuffle=True, num_workers=4, collate_fn=CollatePadding(pad_idx=pad_idx,batch_first=True))